### PR TITLE
Update to add CW, CCW option

### DIFF
--- a/Scripts/Runtime/Lidar/RotateLidar.cs
+++ b/Scripts/Runtime/Lidar/RotateLidar.cs
@@ -12,6 +12,12 @@ namespace FRJ.Sensor
 {
     public class RotateLidar : MonoBehaviour
     {
+        private enum RotateDir {
+            CW,
+            CCW
+        }
+        // Rotate Direction on Y unity axis
+        [SerializeField] RotateDir _rotateDir              = RotateDir.CCW;
         // Number of Layers
         [SerializeField] private int   _numOfLayers        = 16;
         // Number of Increments for one rotation 
@@ -77,7 +83,6 @@ namespace FRJ.Sensor
                 ainc = 0;
             else
                 ainc = (float)(this._maxAzimuthAngle - this._minAzimuthAngle) / (float)this._numOfIncrements;
-            Vector3 fwd = new Vector3(0, 0, 1);
             int index = 0;
             float vangle, aangle;
             for (int incr = 0; incr < this._numOfIncrements; incr++)
@@ -87,7 +92,17 @@ namespace FRJ.Sensor
                     index = layer + incr * this._numOfLayers;
                     vangle = this._minVerticalAngle + (float)layer * vinc;
                     aangle = this._minAzimuthAngle + (float)incr * ainc;
-                    this._commandDirVecs[index] = Quaternion.Euler(-vangle,aangle,0)*fwd;
+                    switch(this._rotateDir)
+                    {
+                        case RotateDir.CCW:
+                            this._commandDirVecs[index] = Quaternion.Euler(-vangle,-aangle,0)*Vector3.forward;
+                            break;
+                        case RotateDir.CW:
+                            this._commandDirVecs[index] = Quaternion.Euler(-vangle,aangle,0)*Vector3.forward;
+                            break;
+                        default:
+                            break;
+                    }
                     this.commands[index] = new RaycastCommand(
                                                               this.transform.position,
                                                               this.transform.rotation * this._commandDirVecs[index],


### PR DESCRIPTION
I added CW, CCW option for RotateLidar class.
CW, CCW means the rotate direction on Y axis (Unity axis).
Sensing direction depends on each sensors.
For example, VLP16 from Velodyne is sensing in CW, but UST30-LC from Hokuyo is sensing in CCW.
- https://velodynelidar.com/wp-content/uploads/2019/12/63-9243-Rev-E-VLP-16-User-Manual.pdf
- https://www.hokuyo-aut.co.jp/search/single.php?serial=201#spec

This PR is related with https://github.com/Field-Robotics-Japan/UnitySensors/issues/6