### PR TITLE
Update LiDAR.cs, Add OpticalMaterial.cs

### DIFF
--- a/Scripts/Runtime/Lidar/OpticalMaterial.cs
+++ b/Scripts/Runtime/Lidar/OpticalMaterial.cs
@@ -1,0 +1,72 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class OpticalMaterial : MonoBehaviour
+{
+    [Header("Parameters")]
+
+    [Range(0.0f, 1.0f)]
+    [SerializeField] private float _roughness;
+
+    [Range(0.0f, 1.0f)]
+    [SerializeField] private float _surfaceReflectance;
+
+    [Range(0.0f, 1.0f)]
+    [SerializeField] private float _specularReflectance;
+
+    [Range(0.0f, 1.0f)]
+    [SerializeField] private float _retroReflectance;
+
+    [Header("Informations (No need to input)")]
+
+    [SerializeField] private float _f_r;
+    [SerializeField] private float _f_d;
+
+    [SerializeField] private float _d;
+    [SerializeField] private float _lambda;
+    [SerializeField] private float _g;
+
+    private float _alpha2;
+
+    public float roughness { get => this._roughness; }
+    public float surfaceReflactance { get => this._surfaceReflectance; }
+    public float specularReflectance { get => this._specularReflectance; }
+    public float retroReflectance { get => this._retroReflectance; }
+
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        this._alpha2 = this._roughness * this._roughness * this._roughness * this._roughness;
+        this._f_r = (1 - this._specularReflectance) * this._retroReflectance/(Mathf.PI * this._alpha2);
+        this._f_d = (1 - this._specularReflectance) * (1 - this._retroReflectance)*this.surfaceReflactance/(Mathf.PI);
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+
+    public float GetReflectance(float theta)
+    {
+        float f_s = this.calc_f_s(theta);
+        float reflectance = f_s + this._f_r + this._f_d;
+        return reflectance;
+    }
+
+    private float calc_f_s(float theta)
+    {
+        this._d = this._alpha2/Mathf.PI/ this.square(this.square(Mathf.Cos(theta))*(this._alpha2 - 1.0f)+1.0f);
+        this._lambda = -1.0f+Mathf.Sqrt((1.0f/this.square(Mathf.Cos(theta))-1.0f)*this._alpha2+1.0f);
+        this._g = 1 / (1 + this._lambda);
+        float f_s = this._d * this._g * this._specularReflectance / square(Mathf.Cos(theta)) * 0.25f;
+        return f_s;
+    }
+
+    private float square(float a)
+    {
+        return a * a;
+    }
+}

--- a/Scripts/Runtime/Lidar/OpticalMaterial.cs.meta
+++ b/Scripts/Runtime/Lidar/OpticalMaterial.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b01832353e2b88c448291da9d5f03ebe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Lidar/RotateLidar.cs
+++ b/Scripts/Runtime/Lidar/RotateLidar.cs
@@ -195,7 +195,7 @@ namespace FRJ.Sensor
                 else
                 {
                     distances[index] = results[index].distance + normrand + offset;
-                    intensities[index] = maxIntensity * minRange / distances[index];
+                    intensities[index] = maxIntensity * minRange * minRange / (distances[index] * distances[index]);
 
                     /*
                     OpticalMaterial om = results[index].collider.gameObject.GetComponent<OpticalMaterial>();

--- a/Scripts/Runtime/Lidar/RotateLidar.cs
+++ b/Scripts/Runtime/Lidar/RotateLidar.cs
@@ -34,6 +34,8 @@ namespace FRJ.Sensor
         [SerializeField] private float _minRange           = 0.1f;
         // Maximum range (m)
         [SerializeField] private float _maxRange           = 100f;
+        // Maximum intensity ()
+        [SerializeField] private float _maxIntensity       = 255f;
         // Scanning rate (Hz)
         [SerializeField] private float _scanRate           = 20f;
         // Random seed
@@ -49,6 +51,7 @@ namespace FRJ.Sensor
         public float maxAzimuthAngle { get => this._maxAzimuthAngle; }
         public float minRange { get => this._minRange; }
         public float maxRange { get => this._maxRange; }
+        public float maxIntensity { get => this._maxIntensity; }
         public float scanRate { get => this._scanRate; }
         public uint randomSeed { get => this._randomSeed; set {this._randomSeed = value; }}
 
@@ -56,6 +59,7 @@ namespace FRJ.Sensor
         public NativeArray<RaycastCommand> commands;
         // Raycast direction vectors
         private Vector3[] _commandDirVecs;
+        private NativeArray<Vector3> commandDirVecsNative;
         // Raycast results
         public NativeArray<RaycastHit> results;
         // Distance data
@@ -73,6 +77,7 @@ namespace FRJ.Sensor
             // allocate commands
             this.commands = new NativeArray<RaycastCommand>(this._numOfLayers*this._numOfIncrements, Allocator.Persistent);
             this._commandDirVecs = new Vector3[this.commands.Length];
+            this.commandDirVecsNative = new NativeArray<Vector3>(this._numOfLayers * this._numOfIncrements, Allocator.Persistent);
             float vinc;
             if(this._numOfLayers == 1)
                 vinc = 0;
@@ -107,6 +112,7 @@ namespace FRJ.Sensor
                                                               this.transform.position,
                                                               this.transform.rotation * this._commandDirVecs[index],
                                                               this._maxRange);
+                    this.commandDirVecsNative[index] = this.transform.rotation * this._commandDirVecs[index];
                 }
             }
     
@@ -130,8 +136,10 @@ namespace FRJ.Sensor
                     intensities = this.intensities
                 };
             // Update parameter
+            this.job.commandDirVecs = this.commandDirVecsNative;
             this.job.minRange = this._minRange;
             this.job.maxRange = this._maxRange;
+            this.job.maxIntensity = this._maxIntensity;
             this.job.random   = new Random(this._randomSeed);
             this.job.sigma    = this._gaussianNoiseSigma;
             this.job.offset   = this._offsetNoise;   
@@ -140,6 +148,7 @@ namespace FRJ.Sensor
         public void Dispose()
         {
             this.commands.Dispose();
+            this.commandDirVecsNative.Dispose();
             this.results.Dispose();
             this.distances.Dispose();
             this.intensities.Dispose();
@@ -148,12 +157,16 @@ namespace FRJ.Sensor
         [BurstCompile]
         public struct updateData : IJobParallelFor
         {
+            public NativeArray<Vector3> commandDirVecs;
+
             [ReadOnly] public NativeArray<RaycastHit> results;
             public NativeArray<float> distances;
             public NativeArray<float> intensities;
 
             [ReadOnly] public float minRange;
             [ReadOnly] public float maxRange;
+
+            [ReadOnly] public float maxIntensity;
 
             public Random random;
             public float sigma;
@@ -182,7 +195,16 @@ namespace FRJ.Sensor
                 else
                 {
                     distances[index] = results[index].distance + normrand + offset;
-                    intensities[index] = 255 + normrand;
+                    intensities[index] = maxIntensity * minRange / distances[index];
+
+                    /*
+                    OpticalMaterial om = results[index].collider.gameObject.GetComponent<OpticalMaterial>();
+                    if (om)
+                    {
+                        float theta = Vector3.Angle(commandDirVecs[index], Vector3.Reflect(results[index].normal, results[index].normal)) * Mathf.Deg2Rad;
+                        intensities[index] *= om.GetReflectance(theta);
+                    }
+                    */
                 }
             }
         }


### PR DESCRIPTION
## 概要
LiDAR.csのレーザー強度計算を変更

## 変更
### LiDAR.cs
レーザー飛翔距離の2乗に反比例するようにレーザー強度の計算式を変更。
下記のOpticalMaterial.csを用いた、物体の反射率を考慮する計算部は、下記の問題があるためコメントアウト中。

問題：RaycastCommandで取得したRaycastHitには衝突対象の情報が含まれていない(並列処理のため取得できない)ため、OpticalMaterial.csなど衝突対象のコンポーネントにアクセスすることが出来ない。

## 新規追加
### OpticalMaterial.cs
表面粗さ・表面反射率・鏡面反射率・再帰反射率・入射角の5パラメータから、物体の反射率を計算するスクリプト。
現在は上記の問題により未使用。
