### PR TITLE
Fix NMEASerializer.cs

### DIFF
--- a/Scripts/Runtime/GPS/NMEASerializer.cs
+++ b/Scripts/Runtime/GPS/NMEASerializer.cs
@@ -84,7 +84,6 @@ namespace FRJ.Sensor
             // Update DGPS data (in this case, empty)
             ret += ",";
             ret += "0000";
-            ret += ",";
 
             // Update checksum
             byte checksum = 0;


### PR DESCRIPTION
NMEAパケットの形式を正しいものに修正(チェックサム部の前のカンマを削除)。
ROSとの通信成功は確認済み。
![image](https://user-images.githubusercontent.com/37181352/178188401-3b2ec440-f3f2-44b3-97b6-6840c6723a58.png)
