### PR TITLE
GPS : New format and gaussian noise 

### DIFF
--- a/Scripts/Runtime/GPS/GPS.cs
+++ b/Scripts/Runtime/GPS/GPS.cs
@@ -9,6 +9,7 @@ namespace FRJ.Sensor
         #region Header("General")
         [Header("General")]
         [SerializeField] private float _updateRate = 10f;
+        [SerializeField] private NMEASerializer.TIME_MODE _timeMode = NMEASerializer.TIME_MODE.SIM;
         [SerializeField] private double _baseLatitude = 35.71020206575301;      // 基地局の緯度
         [SerializeField] private double _baseLongitude = 139.81070039691542;    // 基地局の経度
         [SerializeField] private double _baseAltitude = 3.0;                    // 基地局の標高（海抜高さ）[m]
@@ -89,12 +90,14 @@ namespace FRJ.Sensor
             // GPRMC
             this._serializer.GPRMC_DATA.status = this._gprmc_status;
             this._serializer.GPRMC_DATA.mode = this._gps_mode;
+            this._serializer.GPRMC_DATA.time_mode = this._timeMode;
 
             // GPGGA
             this._serializer.GPGGA_DATA.quality = this._gpgga_quality;
             this._serializer.GPGGA_DATA.satelliteNum = this._gpgga_satelliteNum;
             this._serializer.GPGGA_DATA.hdop = this._HDOP;
             this._serializer.GPGGA_DATA.geoidLevel = this._gpgga_geoidHeight;
+            this._serializer.GPGGA_DATA.time_mode = this._timeMode;
 
             // GPGSA
             this._serializer.GPGSA_DATA.mode = this._gpgsa_mode;

--- a/Scripts/Runtime/GPS/GPS.cs
+++ b/Scripts/Runtime/GPS/GPS.cs
@@ -24,6 +24,11 @@ namespace FRJ.Sensor
         // private string _gpvtg;      // GPVTG message
         // private string _gphdt;      // GPHDT message
 
+        [SerializeField] private Vector3 _velocity;
+        private Vector3 _pos_old;
+        private float _time_old;
+        private const float meterPerSec2knot = 1.9384f;
+
         public float updateRate{ get => this._updateRate; }
         
         public string gprmc { get => this._gprmc; }
@@ -32,25 +37,40 @@ namespace FRJ.Sensor
         // public string gphdt { get => this._gphdt; }
 
         private GeoCoordinate _gc;
-        private NMEASerializer _serializer;
+        [SerializeField] private NMEASerializer _serializer;
 
         public void Init()
         {
+            this._pos_old = this.transform.position;
+            this._time_old = Time.time;
+
             this._gc = new GeoCoordinate(this._baseLatitude, this._baseLongitude);
             this._serializer = new NMEASerializer();
             this._serializer.GPGGA_DATA.geoidLevel = (float)this._geoidHeight;
             this._serializer.GPGGA_DATA.satelliteNum = this._satelliteNum;
             this._serializer.GPGGA_DATA.hdop = (float)this._HDOP;
+            this._serializer.GPRMC_DATA.status = false;
         }
 
         public void updateGPS()
         {
+            float time = Time.time;
+            this._velocity = (this.transform.position - _pos_old) / (time - _time_old);
+            _pos_old = this.transform.position;
+            _time_old = time;
+
             (this._latitude, this._longitude) = this._gc.XZ2LatLon(this.transform.position.x, this.transform.position.z);
             this._altitude = this._baseAltitude + this.transform.position.y;
 
             this._serializer.latitude = (float)this._latitude;
             this._serializer.longitude = (float)this._longitude;
+
             this._serializer.GPGGA_DATA.altitude = (float)this._altitude;
+
+            this._serializer.GPRMC_DATA.groundSpeed = Mathf.Sqrt(_velocity.x * _velocity.x + _velocity.z * _velocity.z)*meterPerSec2knot;
+            float directionOfMovement = Mathf.Atan2(_velocity.x, _velocity.z)*Mathf.Rad2Deg;
+            if (directionOfMovement < 0) directionOfMovement += 360.0f;
+            this._serializer.GPRMC_DATA.directionOfMovement = directionOfMovement;
 
             this._gprmc = this._serializer.GPRMC();
             this._gpgga = this._serializer.GPGGA();

--- a/Scripts/Runtime/GPS/GPS.cs
+++ b/Scripts/Runtime/GPS/GPS.cs
@@ -6,38 +6,67 @@ namespace FRJ.Sensor
 {
     public class GPS : MonoBehaviour
     {
-        [SerializeField] private double _baseLatitude = 35.71020206575301;      // 基地局の緯度 [m]
-        [SerializeField] private double _baseLongitude = 139.81070039691542;    // 基地局の経度 [m]
+        #region Header("General")
+        [Header("General")]
+        [SerializeField] private float _updateRate = 10f;
+        [SerializeField] private double _baseLatitude = 35.71020206575301;      // 基地局の緯度
+        [SerializeField] private double _baseLongitude = 139.81070039691542;    // 基地局の経度
         [SerializeField] private double _baseAltitude = 3.0;                    // 基地局の標高（海抜高さ）[m]
-        [SerializeField] private uint   _satelliteNum = 8;                      // 使用衛星数
-        [SerializeField] private double _HDOP = 1.0;                            // 水平精度低下率
-        [SerializeField] private double _geoidHeight = 36.7071;                 // ジオイド高 [m]
-        [SerializeField] private float _updateRate = 10f; 
+        [SerializeField] private float _HDOP = 1.0f;                            // 水平精度低下率
+        [HideInInspector] public float updateRate { get => this._updateRate; }
+        #endregion
 
-        private double _latitude;   // 緯度 [m]
-        private double _longitude;  // 経度 [m]
-        private double _altitude;   // 標高 [m]
+        #region Header("GPRMC")
+        [Header("GPRMC")]
+        [Tooltip("0 : Available, 1 : Warning")]
+        [SerializeField] private bool _gprmc_status;
+        [SerializeField] private NMEASerializer.GPRMC_MODE _gprmc_mode = NMEASerializer.GPRMC_MODE.NONE;
+        #endregion
 
-        [Header("Informations(No need to input)")]
-        [SerializeField] private string _gprmc;      // GPRMC message
-        [SerializeField] private string _gpgga;      // GPGGA message
-        // private string _gpvtg;      // GPVTG message
-        // private string _gphdt;      // GPHDT message
+        #region Header("GPGGA")
+        [Header("GPGGA")]
+        [SerializeField] private NMEASerializer.GPGGA_QUALITY _gpgga_quality = NMEASerializer.GPGGA_QUALITY.SPS;
+        [SerializeField] private uint _gpgga_satelliteNum = 8;                  // 使用衛星数
+        [SerializeField] private float _gpgga_geoidHeight = 36.7071f;           // ジオイド高 [m]
+        #endregion
 
+        #region Header("GPGSA")
+        [Header("GPGSA")]
+        [SerializeField] private NMEASerializer.GPGSA_MODE _gpgsa_mode = NMEASerializer.GPGSA_MODE.AUTO;
+        [SerializeField] private int[] _gpgsa_satelliteID;
+        [SerializeField] private NMEASerializer.GPGSA_LOCATING_TYPE _gpgsa_locating_type = NMEASerializer.GPGSA_LOCATING_TYPE.THREE_D;
+        [SerializeField] private float _gpgsa_PDOP = 1.0f;                      // 位置精度低下率
+        [SerializeField] private float _gpgsa_VDOP = 1.0f;                      // 垂直精度低下率
+        #endregion
+
+        #region Header("Serializer")
+        [Header("Serializer")]
+        [SerializeField] private NMEASerializer _serializer;
+        #endregion
+
+        #region Header("RawData")
+        [Header("RawData")]
+        [SerializeField] private double _latitude;
+        [SerializeField] private double _longitude;
+        [SerializeField] private double _altitude;
         [SerializeField] private Vector3 _velocity;
+        #endregion
+
+        #region Header("SerializedData")
+        [Header("SerializedData")]
+        [SerializeField] private string _gprmc;
+        [SerializeField] private string _gpgga;
+        [SerializeField] private string _gpgsa;
+
+        [HideInInspector] public string gprmc { get => this._gprmc; }
+        [HideInInspector] public string gpgga { get => this._gpgga; }
+        [HideInInspector] public string gpgsa { get => this._gpgsa; }
+        #endregion
+
+        private GeoCoordinate _gc;
         private Vector3 _pos_old;
         private float _time_old;
         private const float meterPerSec2knot = 1.9384f;
-
-        public float updateRate{ get => this._updateRate; }
-        
-        public string gprmc { get => this._gprmc; }
-        public string gpgga { get => this._gpgga; }
-        // public string gpvtg { get => this._gpvtg; }
-        // public string gphdt { get => this._gphdt; }
-
-        private GeoCoordinate _gc;
-        [SerializeField] private NMEASerializer _serializer;
 
         public void Init()
         {
@@ -46,12 +75,26 @@ namespace FRJ.Sensor
 
             this._gc = new GeoCoordinate(this._baseLatitude, this._baseLongitude);
             this._serializer = new NMEASerializer();
-            this._serializer.GPGGA_DATA.quality = NMEASerializer.GPGGA_QUALITY.SPS;
-            this._serializer.GPGGA_DATA.geoidLevel = (float)this._geoidHeight;
-            this._serializer.GPGGA_DATA.satelliteNum = this._satelliteNum;
-            this._serializer.GPGGA_DATA.hdop = (float)this._HDOP;
-            this._serializer.GPRMC_DATA.status = false;
-            this._serializer.GPRMC_DATA.mode = NMEASerializer.GPRMC_MODE.NONE;
+
+            // GPRMC
+            this._serializer.GPRMC_DATA.status = this._gprmc_status;
+            this._serializer.GPRMC_DATA.mode = this._gprmc_mode;
+
+            // GPGGA
+            this._serializer.GPGGA_DATA.quality = this._gpgga_quality;
+            this._serializer.GPGGA_DATA.satelliteNum = this._gpgga_satelliteNum;
+            this._serializer.GPGGA_DATA.hdop = this._HDOP;
+            this._serializer.GPGGA_DATA.geoidLevel = this._gpgga_geoidHeight;
+
+            // GPGSA
+            this._serializer.GPGSA_DATA.mode = this._gpgsa_mode;
+            this._serializer.GPGSA_DATA.satellightID = new int[this._gpgsa_satelliteID.Length];
+            for (int i = 0; i < this._gpgsa_satelliteID.Length; i++)
+                this._serializer.GPGSA_DATA.satellightID[i] = this._gpgsa_satelliteID[i];
+            this._serializer.GPGSA_DATA.locatingType = this._gpgsa_locating_type;
+            this._serializer.GPGSA_DATA.pdop = this._gpgsa_PDOP;
+            this._serializer.GPGSA_DATA.hdop = this._HDOP;
+            this._serializer.GPGSA_DATA.vdop = this._gpgsa_VDOP;
         }
 
         public void updateGPS()
@@ -67,15 +110,20 @@ namespace FRJ.Sensor
             this._serializer.latitude = (float)this._latitude;
             this._serializer.longitude = (float)this._longitude;
 
-            this._serializer.GPGGA_DATA.altitude = (float)this._altitude;
-
-            this._serializer.GPRMC_DATA.groundSpeed = Mathf.Sqrt(_velocity.x * _velocity.x + _velocity.z * _velocity.z)*meterPerSec2knot;
-            float directionOfMovement = Mathf.Atan2(_velocity.x, _velocity.z)*Mathf.Rad2Deg;
+            // GPRMC
+            this._serializer.GPRMC_DATA.groundSpeed = Mathf.Sqrt(_velocity.x * _velocity.x + _velocity.z * _velocity.z) * meterPerSec2knot;
+            float directionOfMovement = Mathf.Atan2(_velocity.x, _velocity.z) * Mathf.Rad2Deg;
             if (directionOfMovement < 0) directionOfMovement += 360.0f;
             this._serializer.GPRMC_DATA.directionOfMovement = directionOfMovement;
 
+            // GPGGA
+            this._serializer.GPGGA_DATA.altitude = (float)this._altitude;
+
+            // GPGSA
+
             this._gprmc = this._serializer.GPRMC();
             this._gpgga = this._serializer.GPGGA();
+            this._gpgsa = this._serializer.GPGSA();
         }
     }
 }

--- a/Scripts/Runtime/GPS/GPS.cs
+++ b/Scripts/Runtime/GPS/GPS.cs
@@ -51,6 +51,7 @@ namespace FRJ.Sensor
             this._serializer.GPGGA_DATA.satelliteNum = this._satelliteNum;
             this._serializer.GPGGA_DATA.hdop = (float)this._HDOP;
             this._serializer.GPRMC_DATA.status = false;
+            this._serializer.GPRMC_DATA.mode = NMEASerializer.GPRMC_MODE.NONE;
         }
 
         public void updateGPS()

--- a/Scripts/Runtime/GPS/GPS.cs
+++ b/Scripts/Runtime/GPS/GPS.cs
@@ -12,7 +12,7 @@ namespace FRJ.Sensor
         [SerializeField] private double _baseLatitude = 35.71020206575301;      // 基地局の緯度
         [SerializeField] private double _baseLongitude = 139.81070039691542;    // 基地局の経度
         [SerializeField] private double _baseAltitude = 3.0;                    // 基地局の標高（海抜高さ）[m]
-        [SerializeField] private NMEASerializer.GPS_MODE _gps_mode = NMEASerializer.GPS_MODE.NONE;
+        [SerializeField] private NMEASerializer.GPS_MODE _gps_mode = NMEASerializer.GPS_MODE.AUTONOMOUS;
         [SerializeField] private float _HDOP = 1.0f;                            // 水平精度低下率
         [HideInInspector] public float updateRate { get => this._updateRate; }
         #endregion

--- a/Scripts/Runtime/GPS/GPS.cs
+++ b/Scripts/Runtime/GPS/GPS.cs
@@ -9,7 +9,7 @@ namespace FRJ.Sensor
         [SerializeField] private double _baseLatitude = 35.71020206575301;      // 基地局の緯度 [m]
         [SerializeField] private double _baseLongitude = 139.81070039691542;    // 基地局の経度 [m]
         [SerializeField] private double _baseAltitude = 3.0;                    // 基地局の標高（海抜高さ）[m]
-        [SerializeField] private int    _satelliteNum = 8;                      // 使用衛星数
+        [SerializeField] private uint   _satelliteNum = 8;                      // 使用衛星数
         [SerializeField] private double _HDOP = 1.0;                            // 水平精度低下率
         [SerializeField] private double _geoidHeight = 36.7071;                 // ジオイド高 [m]
         [SerializeField] private float _updateRate = 10f; 
@@ -17,13 +17,16 @@ namespace FRJ.Sensor
         private double _latitude;   // 緯度 [m]
         private double _longitude;  // 経度 [m]
         private double _altitude;   // 標高 [m]
-        // private string _gprmc;      // GPRMC message
-        private string _gpgga;      // GPGGA message
+
+        [Header("Informations(No need to input)")]
+        [SerializeField] private string _gprmc;      // GPRMC message
+        [SerializeField] private string _gpgga;      // GPGGA message
         // private string _gpvtg;      // GPVTG message
         // private string _gphdt;      // GPHDT message
 
         public float updateRate{ get => this._updateRate; }
-        // public string gprmc { get => this._gprmc; }
+        
+        public string gprmc { get => this._gprmc; }
         public string gpgga { get => this._gpgga; }
         // public string gpvtg { get => this._gpvtg; }
         // public string gphdt { get => this._gphdt; }
@@ -35,9 +38,9 @@ namespace FRJ.Sensor
         {
             this._gc = new GeoCoordinate(this._baseLatitude, this._baseLongitude);
             this._serializer = new NMEASerializer();
-            this._serializer.geoidLevel = (float)this._geoidHeight;
-            this._serializer.satelliteNum = this._satelliteNum;
-            this._serializer.hdop = (float)this._HDOP;
+            this._serializer.GPGGA_DATA.geoidLevel = (float)this._geoidHeight;
+            this._serializer.GPGGA_DATA.satelliteNum = this._satelliteNum;
+            this._serializer.GPGGA_DATA.hdop = (float)this._HDOP;
         }
 
         public void updateGPS()
@@ -47,8 +50,9 @@ namespace FRJ.Sensor
 
             this._serializer.latitude = (float)this._latitude;
             this._serializer.longitude = (float)this._longitude;
-            this._serializer.altitude = (float)this._altitude;
-            
+            this._serializer.GPGGA_DATA.altitude = (float)this._altitude;
+
+            this._gprmc = this._serializer.GPRMC();
             this._gpgga = this._serializer.GPGGA();
         }
     }

--- a/Scripts/Runtime/GPS/GPS.cs
+++ b/Scripts/Runtime/GPS/GPS.cs
@@ -46,6 +46,7 @@ namespace FRJ.Sensor
 
             this._gc = new GeoCoordinate(this._baseLatitude, this._baseLongitude);
             this._serializer = new NMEASerializer();
+            this._serializer.GPGGA_DATA.quality = NMEASerializer.GPGGA_QUALITY.SPS;
             this._serializer.GPGGA_DATA.geoidLevel = (float)this._geoidHeight;
             this._serializer.GPGGA_DATA.satelliteNum = this._satelliteNum;
             this._serializer.GPGGA_DATA.hdop = (float)this._HDOP;

--- a/Scripts/Runtime/GPS/GPS.cs
+++ b/Scripts/Runtime/GPS/GPS.cs
@@ -17,6 +17,14 @@ namespace FRJ.Sensor
         [HideInInspector] public float updateRate { get => this._updateRate; }
         #endregion
 
+        #region Header("Noise")
+        // Random seed
+        [SerializeField] private uint _randomSeed = 1;
+        // Gaussian Noise sigma
+        [SerializeField] private float _gaussianNoiseSigma_horizontal     = 0.0f;
+        [SerializeField] private float _gaussianNoiseSigma_vertical     = 0.0f;
+        #endregion
+
         #region Header("GPRMC")
         [Header("GPRMC")]
         [Tooltip("0 : Available, 1 : Warning")]
@@ -112,8 +120,9 @@ namespace FRJ.Sensor
             float directionOfMovement = Mathf.Atan2(_velocity.x, _velocity.z) * Mathf.Rad2Deg;
             if (directionOfMovement < 0) directionOfMovement += 360.0f;
 
-            (this._latitude, this._longitude) = this._gc.XZ2LatLon(this.transform.position.x, this.transform.position.z);
-            this._altitude = this._baseAltitude + this.transform.position.y;
+            (this._latitude, this._longitude) = this._gc.XZ2LatLon( this.transform.position.x + GetGaussianNoise() * this._gaussianNoiseSigma_horizontal, 
+                                                                    this.transform.position.z + GetGaussianNoise() * this._gaussianNoiseSigma_horizontal);
+            this._altitude = this._baseAltitude + this.transform.position.y + GetGaussianNoise() * this._gaussianNoiseSigma_vertical;
 
             this._serializer.latitude = (float)this._latitude;
             this._serializer.longitude = (float)this._longitude;
@@ -136,6 +145,16 @@ namespace FRJ.Sensor
             this._gpgga = this._serializer.GPGGA();
             this._gpgsa = this._serializer.GPGSA();
             this._gpvtg = this._serializer.GPVTG();
+        }
+
+        private float GetGaussianNoise()
+        {
+            var rand2 = Random.value;
+            var rand3 = Random.value;
+            float normrand =
+                (float)Mathf.Sqrt(-2.0f * Mathf.Log(rand2)) *
+                (float)Mathf.Cos(2.0f * Mathf.PI * rand3);
+            return normrand;
         }
     }
 }

--- a/Scripts/Runtime/GPS/NMEASerializer.cs
+++ b/Scripts/Runtime/GPS/NMEASerializer.cs
@@ -84,7 +84,6 @@ namespace FRJ.Sensor
             // Update DGPS data (in this case, empty)
             ret += ",";
             ret += "0000";
-            ret += ",";
 
             // Update checksum
             byte checksum = 0;

--- a/Scripts/Runtime/GPS/NMEASerializer.cs
+++ b/Scripts/Runtime/GPS/NMEASerializer.cs
@@ -29,6 +29,14 @@ namespace FRJ.Sensor
         #endregion
 
         #region GPRMC
+        public enum GPRMC_MODE
+        {
+            NONE,
+            AUTONOMOUS,
+            DIFFERENTIAL,
+            ESTIMATED
+        }
+
         [System.Serializable]
         public struct GPRMC_DATA_STRUCT
         {
@@ -37,6 +45,7 @@ namespace FRJ.Sensor
             public float longitude;
             public float groundSpeed;               // 000.0 ~ 999.9 [knot]
             public float directionOfMovement;       // 000.0 ~ 359.9 [deg]
+            public GPRMC_MODE mode;
         }
         [SerializeField] public GPRMC_DATA_STRUCT GPRMC_DATA;
 
@@ -72,7 +81,21 @@ namespace FRJ.Sensor
             ret += ",,";
 
             // Update mode
-            ret += "N";
+            switch (GPRMC_DATA.mode)
+            {
+                case GPRMC_MODE.NONE:
+                    ret += "N";
+                    break;
+                case GPRMC_MODE.AUTONOMOUS:
+                    ret += "A";
+                    break;
+                case GPRMC_MODE.DIFFERENTIAL:
+                    ret += "D";
+                    break;
+                case GPRMC_MODE.ESTIMATED:
+                    ret += "E";
+                    break;
+            }
 
             // Update checksum
             AddChecksum(ref ret);

--- a/Scripts/Runtime/GPS/NMEASerializer.cs
+++ b/Scripts/Runtime/GPS/NMEASerializer.cs
@@ -9,6 +9,14 @@ namespace FRJ.Sensor
     [System.Serializable]
     public class NMEASerializer
     {
+        public enum GPS_MODE
+        {
+            NONE,
+            AUTONOMOUS,
+            DIFFERENTIAL,
+            ESTIMATED
+        }
+
         #region properties
         public float latitude { 
             set{
@@ -29,13 +37,6 @@ namespace FRJ.Sensor
         #endregion
 
         #region GPRMC
-        public enum GPRMC_MODE
-        {
-            NONE,
-            AUTONOMOUS,
-            DIFFERENTIAL,
-            ESTIMATED
-        }
 
         [System.Serializable]
         public struct GPRMC_DATA_STRUCT
@@ -45,7 +46,7 @@ namespace FRJ.Sensor
             public float longitude;
             public float groundSpeed;               // 000.0 ~ 999.9 [knot]
             public float directionOfMovement;       // 000.0 ~ 359.9 [deg]
-            public GPRMC_MODE mode;
+            public GPS_MODE mode;
         }
         [SerializeField] public GPRMC_DATA_STRUCT GPRMC_DATA;
 
@@ -83,16 +84,16 @@ namespace FRJ.Sensor
             // Update mode
             switch (GPRMC_DATA.mode)
             {
-                case GPRMC_MODE.NONE:
+                case GPS_MODE.NONE:
                     ret += "N";
                     break;
-                case GPRMC_MODE.AUTONOMOUS:
+                case GPS_MODE.AUTONOMOUS:
                     ret += "A";
                     break;
-                case GPRMC_MODE.DIFFERENTIAL:
+                case GPS_MODE.DIFFERENTIAL:
                     ret += "D";
                     break;
-                case GPRMC_MODE.ESTIMATED:
+                case GPS_MODE.ESTIMATED:
                     ret += "E";
                     break;
             }
@@ -238,6 +239,62 @@ namespace FRJ.Sensor
 
             // Update VDOP
             ret += GPGSA_DATA.vdop.ToString("0.0");
+
+            // Update checksum
+            AddChecksum(ref ret);
+
+            // Insert CR LF
+            ret += "\r\n";
+
+            return ret;
+        }
+        #endregion
+
+        #region GPVTG
+
+        [System.Serializable]
+        public struct GPVTG_DATA_STRUCT
+        {
+            public float directionOfMovement;       // 000.0 ~ 359.9 [deg]
+            public float groundSpeed_knot;
+            public float groundSpeed_kiloMetersPerHour;
+            public GPS_MODE mode;
+        }
+        [SerializeField] public GPVTG_DATA_STRUCT GPVTG_DATA;
+
+        public string GPVTG()
+        {
+            string ret = "$GPVTG,";
+
+            // Update direction of movement
+            ret += GPVTG_DATA.directionOfMovement.ToString("000.0");
+            ret += ",T,";
+
+            // Update magnetic direction of movement
+            ret += ",M,";
+
+            // Update ground speed
+            ret += GPVTG_DATA.groundSpeed_knot.ToString("000.0");
+            ret += ",N,";
+            ret += GPVTG_DATA.groundSpeed_kiloMetersPerHour.ToString("000.0");
+            ret += ",K,";
+
+            // Update mode
+            switch (GPVTG_DATA.mode)
+            {
+                case GPS_MODE.NONE:
+                    ret += "N";
+                    break;
+                case GPS_MODE.AUTONOMOUS:
+                    ret += "A";
+                    break;
+                case GPS_MODE.DIFFERENTIAL:
+                    ret += "D";
+                    break;
+                case GPS_MODE.ESTIMATED:
+                    ret += "E";
+                    break;
+            }
 
             // Update checksum
             AddChecksum(ref ret);

--- a/Scripts/Runtime/GPS/NMEASerializer.cs
+++ b/Scripts/Runtime/GPS/NMEASerializer.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 
 namespace FRJ.Sensor
 {
+    [System.Serializable]
     public class NMEASerializer
     {
         #region properties
@@ -28,6 +29,7 @@ namespace FRJ.Sensor
         #endregion
 
         #region GPRMC
+        [System.Serializable]
         public struct GPRMC_DATA_STRUCT
         {
             public bool status;                     // 0 : available, 1 : warning
@@ -36,7 +38,7 @@ namespace FRJ.Sensor
             public float groundSpeed;               // 000.0 ~ 999.9 [knot]
             public float directionOfMovement;       // 000.0 ~ 359.9 [deg]
         }
-        public GPRMC_DATA_STRUCT GPRMC_DATA;
+        [SerializeField] public GPRMC_DATA_STRUCT GPRMC_DATA;
 
         public string GPRMC()
         {
@@ -90,6 +92,7 @@ namespace FRJ.Sensor
             DIFFERENTIAL_GPS = 2
         }
 
+        [System.Serializable]
         public struct GPGGA_DATA_STRUCT
         {
             public float latitude;
@@ -100,7 +103,7 @@ namespace FRJ.Sensor
             public float altitude;
             public float geoidLevel;
         }
-        public GPGGA_DATA_STRUCT GPGGA_DATA;
+        [SerializeField] public GPGGA_DATA_STRUCT GPGGA_DATA;
 
         public string GPGGA()
         {
@@ -155,9 +158,9 @@ namespace FRJ.Sensor
 
         private void AddUTCDate(ref string ret)
         {
-            ret += DateTime.UtcNow.Day.ToString("DO2");
-            ret += DateTime.UtcNow.Month.ToString("DO2");
-            ret += DateTime.UtcNow.Year.ToString("DO2");
+            ret += DateTime.UtcNow.Day.ToString("D02");
+            ret += DateTime.UtcNow.Month.ToString("D02");
+            ret += ((int)(DateTime.UtcNow.Year - (int)(DateTime.UtcNow.Year*0.01)*100)).ToString("D02");
             ret += ",";
         }
         private void AddUTCTime(ref string ret)

--- a/Scripts/Runtime/GPS/NMEASerializer.cs
+++ b/Scripts/Runtime/GPS/NMEASerializer.cs
@@ -12,8 +12,8 @@ namespace FRJ.Sensor
         #region properties
         public float latitude { 
             set{
-                this.GPRMC_DATA.latitude 
-                    = this.GPGGA_DATA.latitude 
+                this.GPRMC_DATA.latitude
+                    = this.GPGGA_DATA.latitude
                     = value;
             } 
         }
@@ -166,6 +166,78 @@ namespace FRJ.Sensor
 
             // Update differential reference point ID
             ret += "0000";
+
+            // Update checksum
+            AddChecksum(ref ret);
+
+            // Insert CR LF
+            ret += "\r\n";
+
+            return ret;
+        }
+        #endregion
+
+        #region GPGSA
+        public enum GPGSA_MODE
+        {
+            MANUAL,
+            AUTO
+        }
+
+        public enum GPGSA_LOCATING_TYPE
+        {
+            NONE = 1,
+            TWO_D = 2,
+            THREE_D = 3
+        }
+
+        [System.Serializable]
+        public struct GPGSA_DATA_STRUCT
+        {
+            public GPGSA_MODE mode;
+            public int[] satellightID;
+            public GPGSA_LOCATING_TYPE locatingType;
+            public float pdop;
+            public float hdop;
+            public float vdop;
+        }
+        [SerializeField] public GPGSA_DATA_STRUCT GPGSA_DATA;
+
+        public string GPGSA()
+        {
+            string ret = "$GPGSA,";
+
+            // Update mode
+            switch (GPGSA_DATA.mode)
+            {
+                case GPGSA_MODE.MANUAL:
+                    ret += "M,";
+                    break;
+                case GPGSA_MODE.AUTO:
+                    ret += "A,";
+                    break;
+            }
+
+            // Update locating type
+            ret += ((int)GPGSA_DATA.locatingType).ToString();
+
+            // Update satellight ID
+            for (int i = 0; i < GPGSA_DATA.satellightID.Length && i < 12; i++)
+            {
+                ret += GPGSA_DATA.satellightID[i].ToString("D02");
+                ret += ",";
+            }
+
+            // Update PDOP
+            ret += GPGSA_DATA.pdop.ToString("0.0");
+            ret += ",";
+
+            // Update HDOP
+            ret += GPGSA_DATA.hdop.ToString("0.0");
+            ret += ",";
+
+            // Update VDOP
+            ret += GPGSA_DATA.vdop.ToString("0.0");
 
             // Update checksum
             AddChecksum(ref ret);


### PR DESCRIPTION
### 変更点
* GPGGAフォーマットの修正
* 既存のGPGGAに加え、GPRMC, GPGSA, GPVTGのフォーマットを追加。
GPGSVは不要と判断したため未追加。

* GPSでの計測にガウシアンノイズを追加
現在の仕様では、座標変換を行う前のUnity内座標時点でガウシアンノイズを追加している。

* GPS.csのインスペクタ整理
各フォーマットで共通して必要とする変数はGeneralに、その他は各フォーマットのヘッダー以下に。

### 問題点
GPRMC, GPVTGフォーマット用の速度データにはガウシアンノイズが追加されていない+応答が早すぎて非現実的。

![image](https://user-images.githubusercontent.com/37181352/178422724-3330c37b-4a1d-4b70-8d29-8b6b542087c5.png)
