### PR TITLE
Removed a redundant GetComponent<Rigidbody>() with the existing instance _rb

### DIFF
--- a/Scripts/Runtime/IMU/IMU.cs
+++ b/Scripts/Runtime/IMU/IMU.cs
@@ -68,7 +68,7 @@ namespace FRJ.Sensor
 
             // Raw
             this._geometryQuaternion = new Vector4(this._trans.rotation.x, this._trans.rotation.y, this._trans.rotation.z, this._trans.rotation.w);
-            this._angularVelocity = -1 * this.transform.InverseTransformVector(this.GetComponent<Rigidbody>().angularVelocity);
+            this._angularVelocity = -1 * this.transform.InverseTransformVector(this._rb.angularVelocity);
             this._linearAcceleration = acceleration;
 
             // Apply Gaussian Noise


### PR DESCRIPTION
This code should use the existing instance initialized here https://github.com/Field-Robotics-Japan/UnitySensors/blob/main/Scripts/Runtime/IMU/IMU.cs#L51